### PR TITLE
Calcular duracao do saldo de estoque

### DIFF
--- a/src/domain/repositories/sells.repository.interface.ts
+++ b/src/domain/repositories/sells.repository.interface.ts
@@ -14,6 +14,7 @@ export interface ISellsRepository {
   syncroStatusSells(): Promise<void>;
   sellsByDate(fromDate?: string): Promise<Venda[]>;
   sellsBetweenDates(fromDate: string, toDate?: string): Promise<Venda[]>;
+  getSellsByDateRange(fromDate: Date, toDate: Date): Promise<Venda[]>;
   getSellByCode(id: number): Promise<Venda>;
   exportTiny(id: number): Promise<string>;
   updateSellStatus(UpdateSellStatusDto: UpdateSellStatusDto): Promise<string>;

--- a/src/domain/repositories/stock.repository.interface.ts
+++ b/src/domain/repositories/stock.repository.interface.ts
@@ -1,4 +1,4 @@
-import { StockImportResponse, StockLiquid } from 'src/modules/stock/dto';
+import { StockImportResponse, StockLiquid, StockDurationDto } from 'src/modules/stock/dto';
 import { Distribuidor, Estoque, Venda } from '../../infrastructure/database/entities';
 
 export interface IStockRepository {
@@ -7,4 +7,5 @@ export interface IStockRepository {
   importStockFromNfeXml(filePath: string, typeId: number): Promise<StockImportResponse>;
   getStockLiquid(): Promise<StockLiquid[]>;
   findAllDistributors(): Promise<Distribuidor[]>;
+  getStockDuration(produtoId: number, periodoAnalise?: number): Promise<StockDurationDto>;
 }

--- a/src/modules/sells/services/sells.service.ts
+++ b/src/modules/sells/services/sells.service.ts
@@ -516,6 +516,31 @@ export class SellsService implements ISellsRepository {
     });
   }
 
+  async getSellsByDateRange(fromDate: Date, toDate: Date): Promise<Venda[]> {
+    return this.vendaRepository.find({
+      where: {
+        data_criacao: Raw(
+          alias => `${alias} BETWEEN :fromDate AND :toDate`,
+          { 
+            fromDate: fromDate.toISOString(), 
+            toDate: toDate.toISOString() 
+          }
+        ),
+      },
+      relations: [
+        'cliente.grupo',
+        'cliente.cidade.estado',
+        'vendedor',
+        'status_pagamento',
+        'status_venda',
+        'itensVenda.produto',
+        'itensVenda.produto.unidade',
+        'itensVenda.produto.fornecedor', 
+        'tipo_pedido'
+      ],
+    });
+  }
+
   async getSellByCode(id: number): Promise<Venda> {
     return this.vendaRepository.findOne({
       where: { codigo: id },

--- a/src/modules/stock/controllers/stock.controller.ts
+++ b/src/modules/stock/controllers/stock.controller.ts
@@ -1,10 +1,10 @@
-import { Body, Controller, Get, Param, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UploadedFile, UseInterceptors, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { StockService } from '../services/stock.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { Distribuidor, Produto, SaidaEstoque } from '../../../infrastructure/database/entities';
-import { StockImportResponse, StockLiquid, StockOutDto } from '../dto';
+import { StockImportResponse, StockLiquid, StockOutDto, StockDurationDto } from '../dto';
 
 ApiTags('stock')
 @Controller('stock')
@@ -69,5 +69,14 @@ export class StockController {
   @UseInterceptors(FileInterceptor('file'))
   async updateCestByXml(@UploadedFile() file: Express.Multer.File): Promise<{ message: string, updated: number, notFound: string[] }> {
     return this.stockService.getCestByXmlBuffer(file.buffer);
+  }
+
+  @ApiOperation({ summary: 'Calcular quantos dias o estoque de um produto irá durar' })
+  @Get('duration/:produtoId')
+  async getStockDuration(
+    @Param('produtoId') produtoId: number,
+    @Query('periodoAnalise') periodoAnalise?: number
+  ): Promise<StockDurationDto> {
+    return this.stockService.getStockDuration(produtoId, periodoAnalise || 30);
   }
 }

--- a/src/modules/stock/dto/stock.dto.ts
+++ b/src/modules/stock/dto/stock.dto.ts
@@ -37,5 +37,16 @@ export interface Last10OutDto {
   };
 }
 
+export interface StockDurationDto {
+  produto_id: number;
+  codigo: string;
+  nome: string;
+  saldo_estoque: number;
+  consumo_medio_diario: number;
+  dias_duracao: number;
+  periodo_analise_dias: number;
+  data_calculo: string;
+}
+
 
 


### PR DESCRIPTION
Adiciona um método e endpoint para calcular a duração do estoque de um produto com base no consumo histórico.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f47e74f-ac5a-44f5-aa1a-68907bc56180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f47e74f-ac5a-44f5-aa1a-68907bc56180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

